### PR TITLE
Filecheck

### DIFF
--- a/Dumbledraw/rootfile_parser.py
+++ b/Dumbledraw/rootfile_parser.py
@@ -57,10 +57,18 @@ class Rootfile_parser(object):
         available_processes = [entry.GetName() for entry in self._rootfile.Get(hist_hash.split('/')[0]).GetListOfKeys()]
         if hist_hash.split('/')[1] in available_processes:
             return self._rootfile.Get(hist_hash)
+        elif len(available_processes) != 0:
+            hist_nbins = self._rootfile.Get('{}/{}'.format(hist_hash.split('/')[0],available_processes[0])).GetNbinsX()
+            hist_range = [self._rootfile.Get('{}/{}'.format(hist_hash.split('/')[0],available_processes[0])).GetBinLowEdge(1), 
+                self._rootfile.Get('{}/{}'.format(hist_hash.split('/')[0],available_processes[0])).GetBinLowEdge(hist_nbins+1)]
+            logger.warning("%s in %s does not exist !" % (hist_hash, self._rootfilename))
+            logger.debug(" Available Histograms are: %s" % available_processes)
+            logger.debug(" Returning a dummy histogram for %s with %s bins in %s " % (process, hist_nbins, hist_range))
+            return ROOT.TH1F(hist_hash,process,hist_nbins,hist_range[0],hist_range[1])
         else:
-            logger.warning("%s in %s does not exist ! Returning empty histogram instead !" % (hist_hash, self._rootfilename))
-            logger.warning(" Available Histograms are: %s" % available_processes)
-            return ROOT.TH1F(hist_hash,process,10,0,1)
+            logger.fatal(" None of the requested Histograms are available in %s. Aborting." % hist_hash.split('/')[0])
+            raise Exception
+
 
     def get_bins(self, era, channel, category, process, syst=None):
         hist = self.get(era, channel, category, process, syst)

--- a/Dumbledraw/rootfile_parser.py
+++ b/Dumbledraw/rootfile_parser.py
@@ -53,7 +53,14 @@ class Rootfile_parser(object):
             hist_hash = hist_hash.format(plottype="_" + self._type, unc="")
         logger.debug(
             "Try to access %s in %s" % (hist_hash, self._rootfilename))
-        return self._rootfile.Get(hist_hash)
+        # perform check if file is available and otherwise return some dummy TH1F
+        available_processes = [entry.GetName() for entry in self._rootfile.Get(hist_hash.split('/')[0]).GetListOfKeys()]
+        if hist_hash.split('/')[1] in available_processes:
+            return self._rootfile.Get(hist_hash)
+        else:
+            logger.warning("%s in %s does not exist ! Returning empty histogram instead !" % (hist_hash, self._rootfilename))
+            logger.warning(" Available Histograms are: %s" % available_processes)
+            return ROOT.TH1F(hist_hash,process,10,0,1)
 
     def get_bins(self, era, channel, category, process, syst=None):
         hist = self.get(era, channel, category, process, syst)

--- a/Dumbledraw/rootfile_parser.py
+++ b/Dumbledraw/rootfile_parser.py
@@ -58,13 +58,14 @@ class Rootfile_parser(object):
         if hist_hash.split('/')[1] in available_processes:
             return self._rootfile.Get(hist_hash)
         elif len(available_processes) != 0:
-            hist_nbins = self._rootfile.Get('{}/{}'.format(hist_hash.split('/')[0],available_processes[0])).GetNbinsX()
-            hist_range = [self._rootfile.Get('{}/{}'.format(hist_hash.split('/')[0],available_processes[0])).GetBinLowEdge(1), 
-                self._rootfile.Get('{}/{}'.format(hist_hash.split('/')[0],available_processes[0])).GetBinLowEdge(hist_nbins+1)]
             logger.warning("%s in %s does not exist !" % (hist_hash, self._rootfilename))
             logger.debug(" Available Histograms are: %s" % available_processes)
-            logger.debug(" Returning a dummy histogram for %s with %s bins in %s " % (process, hist_nbins, hist_range))
-            return ROOT.TH1F(hist_hash,process,hist_nbins,hist_range[0],hist_range[1])
+            logger.debug(" Returning a dummy histogram ")
+            dummy = self._rootfile.Get('{}/{}'.format(hist_hash.split('/')[0],available_processes[0]))
+            dummy.Reset()
+            dummy.SetTitle(process)
+            dummy.SetName(hist_hash)
+            return dummy
         else:
             logger.fatal(" None of the requested Histograms are available in %s. Aborting." % hist_hash.split('/')[0])
             raise Exception


### PR DESCRIPTION
Added functionality, that Dumbledraw does not crash anymore if a requested histogram is not present in a file. 
The solution now would be a warning message, and returning a dummy histogram, that has the dimensions (nbins, and lower and high edge) of any other histogram in the file. This way, no resizing has to be done. 